### PR TITLE
LIBSEARCH-200. Added config/searchers/lib_guides_database_config.yml

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,0 @@
-LIB_GUIDES_DATABASE_QUERY_TEMPLATE=https://lib.guides.umd.edu/process/az/dbsearch?action=520&site_id=1504&is_widget=0{&search}
-
-LIB_GUIDES_DATABASE_LOADED_LINK_TEMPLATE=https://lib.guides.umd.edu/az.php{?q}
-
-LIB_GUIDES_DATABASE_NO_RESULTS_LINK=https://lib.guides.umd.edu/az.php

--- a/config/searchers/lib_guides_database_config.yml
+++ b/config/searchers/lib_guides_database_config.yml
@@ -1,0 +1,16 @@
+defaults: &defaults
+  query_template: "https://lib.guides.umd.edu/process/az/dbsearch?action=520&site_id=<%= ENV['LIB_GUIDES_SITE_ID'] %>&is_widget=0{&search}"
+  loaded_link_template: "https://lib.guides.umd.edu/az.php{?q}"
+  no_results_link: "https://lib.guides.umd.edu/az.php"
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/env_example
+++ b/env_example
@@ -43,6 +43,7 @@ DATABASE_FINDER_HIPPO_SITE_URL=
 LIB_ANSWERS_IID=
 
 # --- config/searchers/lib_guides_config.yml
+# --- config/searchers/lib_guides_database_config.yml
 # The URL for the LibGuides API
 LIB_GUIDES_URL=https://lgapi-us.libapps.com/1.1/guides/
 
@@ -65,17 +66,3 @@ WORLD_CAT_DISCOVERY_API_SECRET=
 # --- config/searchers/world_cat_discovery_api_article_config.yml
 # The WorldCat Knowledge Base API OpenURL Resolve wskey
 WORLD_CAT_OPEN_URL_RESOLVER_WSKEY=
-
-# --- lib_guides_database_config.yml
-# RFC 6570 URI template for the LibGuides "API" search endpoint. The first
-# variable in the template will be set to the user's current query when executing
-# a search. Any additional variables will be ignored.
-LIB_GUIDES_DATABASE_QUERY_TEMPLATE=
-
-# RFC 6570 URI template for the LibGuides search page. The first variable in the
-# template will be set to the user's current query when executing a search. Any
-# additional variables will be ignored.
-LIB_GUIDES_DATABASE_LOADED_LINK_TEMPLATE=
-
-# URL to link to when there are no search results for the user's current query.
-LIB_GUIDES_DATABASE_NO_RESULTS_LINK=


### PR DESCRIPTION
Added a "config/searchers/lib_guides_database_config.yml" file to
configure the "quick_search-lib_guides_database_searcher".

The "searchumd" application is permitted to have UMD-specific
configuration values in it. And while it hasn't always been done
consistently, the "env_example"/".env" file is mainly intended for
password/API keys, or configuration values that change between
the test/qa/prod servers.

In this case, the configuration variables:

* LIB_GUIDES_DATABASE_QUERY_TEMPLATE
* LIB_GUIDES_DATABASE_LOADED_LINK_TEMPLATE
* LIB_GUIDES_DATABASE_NO_RESULTS_LINK

are all referencing third-party endpoints that will not likely
change between test/qa/prod servers. Therefore added a
"config/searchers/lib_guides_database_config.yml" file to hold
these values (the "query_template" (LIB_GUIDES_DATABASE_QUERY_TEMPLATE)
value is parameterized to use the "LIB_GUIDES_SITE_ID" from the ".env"
file).

This removes the need for the ".env.test" file, and the additional
environment variables in the "env_example"/".env" file.

https://issues.umd.edu/browse/LIBSEARCH-200